### PR TITLE
fix(cli): redact API key in output instead of logging it in plaintext

### DIFF
--- a/.changeset/redact-api-key-in-cli-output.md
+++ b/.changeset/redact-api-key-in-cli-output.md
@@ -1,0 +1,5 @@
+---
+"@pimlico/cli": patch
+---
+
+Redact the API key in CLI output instead of printing it in plaintext. When the CLI is run under a coding agent (e.g. Claude Code), stdout is captured into the chat context, so logging the raw key leaked the credential. The received key is now masked (short prefix + suffix) — enough to confirm the right key was received without exposing the usable secret.

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -121,6 +121,17 @@ function updateEnvFile(envPathInput: string, envVar: string, apiKeyId: string) {
     fs.writeFileSync(envPath, content, { encoding: "utf8" })
 }
 
+// Mask a credential so it is never printed in full. Coding agents (e.g. Claude
+// Code) capture stdout into their chat context, so logging the raw key would
+// leak it. Keep just enough (a short prefix + suffix) to let the user confirm
+// the right key was received without exposing the usable secret.
+function redactSecret(secret: string) {
+    if (secret.length <= 8) {
+        return "*".repeat(secret.length)
+    }
+    return `${secret.slice(0, 4)}…${secret.slice(-4)}`
+}
+
 function openBrowser(url: string) {
     try {
         // macOS, Linux, Windows
@@ -159,7 +170,9 @@ async function main() {
                 res.setHeader("Content-Type", "text/plain")
                 if (apiKey) {
                     res.end("API key received! You can now close this tab.")
-                    console.log(`\n✅  Received API key id: ${apiKey}`)
+                    console.log(
+                        `\n✅  Received API key: ${redactSecret(apiKey)}`
+                    )
                     updateEnvFile(envPath, envVar, apiKey)
                     console.log(`${envPath} updated with ${envVar}`)
                     server.close()


### PR DESCRIPTION
## Problem

The CLI prints the received Pimlico API key in plaintext on the callback:

```js
console.log(`\n✅  Received API key id: ${apiKey}`)
```

This CLI is commonly run by a coding agent (e.g. Claude Code), which captures stdout into its chat context. As a result the **live API key leaks into the agent's transcript**.

## Fix

Add a `redactSecret` helper and mask the key in the log line (short prefix + suffix). The user can still confirm the correct key arrived, but the usable secret is never printed. The full key is still written to the `.env` file as before — only the terminal output changes.

```
✅  Received API key: pim_…a1b2
```

## Notes

- Only the single log line handled a credential, so this is the only change needed.
- Includes a `patch` changeset for `@pimlico/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)